### PR TITLE
fix compatibility with recent IP-Symcon 5.0 update

### DIFF
--- a/HUEDevice.php
+++ b/HUEDevice.php
@@ -326,7 +326,7 @@ abstract class HUEDevice extends IPSModule {
    * HUE_GetValue($id, $key)
    * Liefert einen Lampenparameter (siehe HUE_SetValue)
    */
-  public function GetValue(string $key) {
+  public function GetValue($key) {
     switch ($key) {
       default:
         $value = GetValue(@IPS_GetObjectIDByIdent($key, $this->InstanceID));


### PR DESCRIPTION
IP-Symcon introduced its own GetValue function which does not specify the type hint